### PR TITLE
Use pg.js instead of pg to avoid dependency on native client bindings

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -1,7 +1,7 @@
 /*!
  * PostgreSQL connector for LoopBack
  */
-var postgresql = require('pg');
+var postgresql = require('pg.js');
 var jdb = require('loopback-datasource-juggler');
 var util = require('util');
 var debug = require('debug')('loopback:connector:postgresql');

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "async": "~0.9.0",
-    "pg": "~3.1.0",
+    "pg.js": "~3.1.0",
     "debug": "~0.8.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
We're not using the native bindings anyway - this way, loopback-connector-postgresql can be used as part of a project on a VM that does not have postgres installed.
