### PR TITLE
Pass connection errors to callback

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -101,6 +101,9 @@ PostgreSQL.prototype.connect = function (callback) {
       // console.log(self.connection);
       callback && callback(err, self.connection);
     } else {
+      if (callback) {
+        return callback(err);
+      }
       console.error(err);
       throw err;
     }


### PR DESCRIPTION
Studio and loopback-workspace call `connect` to check if the connection parameters are correct.

Before this change, the Node process crash when connection fails. After this change, the connection error is reported via the callback.

/to @raymondfeng 
