### PR TITLE
Fixes issue #27, updateOrCreate returns incorrect type.

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -288,60 +288,6 @@ PostgreSQL.prototype.create = function (model, data, callback) {
 };
 
 /**
- * Update if the model instance exists with the same id or create a new instance
- *
- * @param {String} model The model name
- * @param {Object} data The model instance data
- * @callback {Function} [callback] The callback function
- * @param {String|Error} err The error string or object
- * @param {Object} The updated model instance
- */
-PostgreSQL.prototype.updateOrCreate = function (model, data, callback) {
-  var self = this;
-  var props = self._categorizeProperties(model, data);
-  var idColumns = props.ids.map(function(key) {
-    return self.columnEscaped(model, key); }
-  );
-  var nonIdsInData = props.nonIdsInData;
-  var query = [];
-  query.push('WITH update_outcome AS (UPDATE ', self.tableEscaped(model), ' SET ');
-  query.push(self.toFields(model, data, false));
-  query.push(' WHERE ');
-  query.push(idColumns.map(function (key, i) {
-    return ((i > 0) ? ' AND ' : ' ') + key + '=$' + (nonIdsInData.length + i + 1);
-  }).join(','));
-  query.push(' RETURNING ', idColumns.join(','), ')');
-  query.push(', insert_outcome AS (INSERT INTO ', self.tableEscaped(model), ' ');
-  query.push(self.toFields(model, data, true));
-  query.push(' WHERE NOT EXISTS (SELECT * FROM update_outcome) RETURNING ', idColumns.join(','), ')');
-  query.push(' SELECT * FROM update_outcome UNION ALL SELECT * FROM insert_outcome');
-  var queryParams = [];
-  nonIdsInData.forEach(function(key) {
-    queryParams.push(data[key]);
-  });
-  props.ids.forEach(function(key) {
-    queryParams.push(data[key] || null);
-  });
-  var idColName = self.idColumn(model);
-  self.query(query.join(''), queryParams, function(err, info) {
-    if (err) {
-      return callback(err);
-    }
-    var idValue = null;
-    if (info && info[0]) {
-      idValue = info[0][idColName];
-      self.find(model, idValue, function(err, data) {
-        if (err) { return callback(err); }
-        return callback(err, data);
-      });
-    } else {
-      return callback(new Error('Insert query did not return model id.'));
-    }
-  });
-};
-
-
-/**
  * Save the model instance to PostgreSQL DB
  * @param {String} model The model name
  * @param {Object} data The model instance data


### PR DESCRIPTION
Method `updateOrCreate` incorrectly returns model ID. This PR updates method to return a model instance instead.
