### PR TITLE
allow false value for BOOLEAN NOT NULL column

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -266,16 +266,8 @@ PostgreSQL.prototype.create = function (model, data, callback) {
     return self.columnEscaped(model, key)}).join(',')
   );
 
-  var queryParams = [];
-  props.nonIdsInData.forEach(function(key) {
-    queryParams.push(data[key] !== undefined ? data[key] : null);
-  });
-  props.idsInData.forEach(function(key) {
-    queryParams.push(data[key] || null);
-  });
-
   var idColName = self.idColumn(model);
-  this.query(sql.join(''), queryParams, function (err, info) {
+  this.query(sql.join(''), generateQueryParams(data, props), function (err, info) {
     if (err) {
       return callback(err);
     }
@@ -360,15 +352,7 @@ PostgreSQL.prototype.save = function (model, data, callback) {
       (props.nonIdsInData.length + i + 1));
   });
 
-  var queryParams = [];
-  props.nonIdsInData.forEach(function(key) {
-   queryParams.push(data[key] !== undefined ? data[key] : null);
-  });
-  props.ids.forEach(function(key) {
-    queryParams.push(data[key] || null);
-  });
-
-  self.query(sql.join(''), queryParams, function (err) {
+  self.query(sql.join(''), generateQueryParams(data, props), function (err) {
     callback(err);
   });
 };
@@ -381,17 +365,8 @@ PostgreSQL.prototype.update =
       this.toFields(model, data), ' ', whereClause].join('');
 
     var props = this._categorizeProperties(model, data);
-    var queryParams = [];
-    props.nonIdsInData.forEach(function(key) {
-      queryParams.push(data[key] !== undefined ? data[key] : null);
-    });
-    props.ids.forEach(function (key) {
-      if (data[key] !== undefined) {
-        queryParams.push(data[key] || null);
-      }
-    });
 
-    this.query(sql, queryParams, function (err, result) {
+    this.query(sql, generateQueryParams(data, props), function (err, result) {
       if (callback) {
         callback(err, result);
       }
@@ -1528,6 +1503,19 @@ function mapPostgreSQLDatatypes(typeName) {
 
 function propertyHasNotBeenDeleted(model, propName) {
   return !!this._models[model].properties[propName];
+}
+
+function generateQueryParams(data, props) {
+    var queryParams = [];
+
+    function pushToQueryParams(key) {
+        queryParams.push(data[key] !== undefined ? data[key] : null);
+    }
+
+    props.nonIdsInData.forEach(pushToQueryParams);
+    props.idsInData.forEach(pushToQueryParams);
+
+    return queryParams;
 }
 
 require('./discovery')(PostgreSQL);

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -38,9 +38,9 @@ describe('postgresql connector', function () {
   });
 
   it('should support updating boolean types with false value', function(done) {
-    Post.update({id: post.id}, {approved: false}, function(err, p) {
+    Post.update({id: post.id}, {approved: false}, function(err) {
       should.not.exists(err);
-      Post.findById(p.id, function(err, p) {
+      Post.findById(post.id, function(err, p) {
         should.not.exists(err);
         p.should.have.property('approved', false);
         done();


### PR DESCRIPTION
For the below model property I was not able to set the value to false. When I removed the NOT NULL constraint then the field would get set to NULL. This looked correct in the API, but was wrong in the database.

"approved": {
      "type": "Boolean",
      "required": true,
      "length": null,
      "precision": null,
      "scale": null,
      "postgresql": {
        "columnName": "approved",
        "dataType": "boolean",
        "dataLength": null,
        "dataPrecision": null,
        "dataScale": null,
        "nullable": "NO"
      }
    }
