### PR TITLE
added optional schema

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -354,11 +354,13 @@ function mixinMigration(PostgreSQL) {
       createExtensions = 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";';
     }
 
+    let createSchema = (typeof self.settings.migrationCreateSchema !== 'undefined') ?  self.settings.migrationCreateSchema : true
+
     // Please note IF NOT EXISTS is introduced in postgresql v9.3
     self.execute(
       createExtensions +
-      'CREATE SCHEMA ' +
-      self.escapeName(self.schema(model)),
+      (createSchema ? 'CREATE SCHEMA ' +
+      self.escapeName(self.schema(model)): ''),
       function(err) {
         if (err && err.code !== '42P06') {
           return cb && cb(err);


### PR DESCRIPTION
This pull add an optional settings (migrationCreateSchema) in the datasource allowing the user to decide if he wants to create the schema or not.
This will allow the user to use migration on already existing schemas in PostgreSQL

Fixes #446

## Checklist

- [x ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
