### PR TITLE
Fix bug multicolumn indexes dropped on autoupdate

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -823,7 +823,10 @@ function mixinMigration(PostgreSQL) {
             ((si.options && !!si.options.unique) === i.unique); // compare unique
 
           // if this is a multi-column query, verify that the order matches
-          const siKeys = Object.keys(si.keys);
+          const siKeys = si.keys.map((key) => {
+            return key[0];
+          });
+
           if (identical && siKeys.length > 1) {
             if (siKeys.length !== i.keys.length) {
               // lengths differ, obviously non-matching


### PR DESCRIPTION
Multicolumn indexes are always being dropped on autoupdate regardless of if
their definition has changed. Changes:

- Fix mapping of property name from the keys of normalized index definition
- Add multicolumn index tests

Fixes #464 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
