### PR TITLE
Defensively drop constraints during migrations

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -586,7 +586,7 @@ function mixinMigration(PostgreSQL) {
         }
 
         if (needsToDrop) {
-          sql.push('DROP CONSTRAINT ' + self.escapeName(fk.fkName));
+          sql.push('DROP CONSTRAINT IF EXISTS ' + self.escapeName(fk.fkName));
           removedFks.push(fk); // keep track that we removed these
         }
 


### PR DESCRIPTION
When `PostgreSQL.prototype.getDropForeignKeys` gets called with duplicated foreign keys, an invalid `ALTER TABLE` statement gets created. This is because the duplicates are mapped to multiple `DROP CONSTRAINT fk_key` SQL actions, e.g.:

```sql
-- This will throw an error
ALTER TABLE "public"."foo"
  DROP CONSTRAINT "fk_duplicatedKey",
  DROP CONSTRAINT "fk_duplicatedKey",
  DROP CONSTRAINT "fk_duplicatedKey",
  DROP CONSTRAINT "fk_otherKey"
```

As the `DROP CONSTRAINT` actions are run sequentially, when the first action gets executed by PostgreSQL, the next one (for the same, but already dropped key) will no longer cause an SQL error thanks to the added IF EXISTS check:

```sql
-- This is valid SQL
ALTER TABLE "public"."foo"
  DROP CONSTRAINT IF EXISTS "fk_duplicatedKey",
  DROP CONSTRAINT IF EXISTS "fk_duplicatedKey",
  DROP CONSTRAINT IF EXISTS "fk_duplicatedKey",
  DROP CONSTRAINT IF EXISTS "fk_otherKey"
```

Please note, this is really a hack that fixes `npm run migrate` operations I have experienced when working on my project. We still need to understand why the `getDropForeignKeys` method gets called with duplicated foreign keys in certain conditions but I believe ensuring the generated SQL code is valid is still a step in the right direction.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine (with the exception of 1-2 tests that keep timing out both on the upstream and my fork master branches)
- [ ] New tests added or existing tests modified to cover all changes (this part of code does not seem to have unit test coverage at the moment)
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
