### PR TITLE
feat(operators): add fts match using postgres @@ operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ CustomerRepository.find({
 PostgreSQL supports the following PostgreSQL-specific operators:
 
 - [`contains`](#operator-contains)
+- [`match`](#operator-match)
 
 Please note extended operators are disabled by default, you must enable
 them at datasource level or model level by setting `allowExtendedOperators` to
@@ -591,6 +592,36 @@ const posts = await postRepository.find({
   where: {
     {
       categories: {'contains': ['AA']},
+    }
+  }
+});
+```
+
+### Operator `match`
+
+The `match` operator allows you to perform a [full text search using the `@@` operator](https://www.postgresql.org/docs/10/textsearch-tables.html#TEXTSEARCH-TABLES-SEARCH) in PostgreSQL.
+
+Assuming a model such as this:
+```ts
+@model({
+  settings: {
+    allowExtendedOperators: true,
+  }
+})
+class Post {
+  @property({
+    type: 'string',
+  })
+  content: string;
+}
+```
+You can query the content field as follows:
+
+```ts
+const posts = await postRepository.find({
+  where: {
+    {
+      content: {match: 'someString'},
     }
   }
 });

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -537,6 +537,8 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
     case 'contains':
       return new ParameterizedSQL(columnName + ' @> array[' + operatorValue.map((v) => `'${v}'`) + ']::'
         + propertyDefinition.postgresql.dataType);
+    case 'match':
+      return new ParameterizedSQL(`to_tsvector(${columnName}) @@ to_tsquery('${operatorValue}')`);
     default:
       // invoke the base implementation of `buildExpression`
       return this.invokeSuper('buildExpression', columnName, operator,

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -281,6 +281,24 @@ describe('postgresql connector', function() {
     found.map(p => p.title).should.deepEqual(['Growing LoopBack Community']);
   });
 
+  it('should support full text search for text type fields using simple string query', async () => {
+    await Post.create({
+      title: 'Loopback joined the OpenJS Foundation',
+      categories: ['Loopback', 'Announcements'],
+    });
+    await Post.create({
+      title: 'Loopback is a new incubating project in the OpenJS foundation',
+      categories: ['Loopback', 'Community'],
+    });
+
+    const found = await Post.find({where: {and: [
+      {
+        title: {match: 'joining'},
+      },
+    ]}});
+    found.map(p => p.title).should.deepEqual(['Loopback joined the OpenJS Foundation']);
+  });
+
   it('should support boolean types with false value', function(done) {
     Post.create(
       {title: 'T2', content: 'C2', approved: false, created: created},


### PR DESCRIPTION
- Adds an operators for full text search based on the `@@` operator in PostgreSQL.

Fixes #484 

## Checklist

- [X] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [X] `npm test` passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [X] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
