### PR TITLE
fix: disregard empty and/or fields in buildSelect

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -623,11 +623,13 @@ PostgreSQL.prototype._buildWhere = function(model, where) {
             branches.push(stmtForClause.sql);
           }
         }
-        stmt.merge({
-          sql: '(' + branches.join(' ' + key.toUpperCase() + ' ') + ')',
-          params: branchParams,
-        });
-        whereStmts.push(stmt);
+        if (branches.length > 0) {
+          stmt.merge({
+            sql: '(' + branches.join(' ' + key.toUpperCase() + ' ') + ')',
+            params: branchParams,
+          });
+          whereStmts.push(stmt);
+        }
         continue;
       }
       // The value is not an array, fall back to regular fields

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -424,6 +424,15 @@ describe('postgresql connector', function() {
       });
     });
 
+    it('should disregard empty and/or fields', function(done) {
+      Post.find({where: {and: []}}, function(err, post) {
+        should.not.exist(err);
+        should.exist(post);
+        post.length.should.not.equal(0);
+        done();
+      });
+    });
+
     it('should preserve order of and/or in where', async function() {
       await Post.create({title: 'T3', content: 'C3', approved: false});
       // WHERE (title='T3' OR approved=false) AND (content='C2')


### PR DESCRIPTION
Prior to v5.2.1, empty and/or fields were handled gracefully. After the upgrade to v5.2.1, this change and the connector would through an error `syntax error at or near ")"`

Fixes https://github.com/loopbackio/loopback-connector-postgresql/issues/483

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
