### PR TITLE
feat(postgresql): add support for multiple insert in one query using createAll() of connector

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -116,6 +116,8 @@ PostgreSQL.prototype.getDefaultSchemaName = function() {
   return 'public';
 };
 
+PostgreSQL.prototype.multiInsertSupported = true;
+
 /**
  * Connect to PostgreSQL
  * @callback {Function} [callback] The callback after the connection is established
@@ -589,6 +591,15 @@ PostgreSQL.prototype.getInsertedId = function(model, info) {
     idValue = info[0][idColName];
   }
   return idValue;
+};
+
+PostgreSQL.prototype.getInsertedIds = function(model, info) {
+  const idColName = this.idColumn(model);
+  let idValues;
+  if (info && Array.isArray(info)) {
+    idValues = info.map((data) => data[idColName]);
+  }
+  return idValues;
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bluebird": "^3.4.6",
         "chalk": "^4.0.0",
         "debug": "^4.1.1",
-        "loopback-connector": "^5.0.0",
+        "loopback-connector": "^5.1.1",
         "pg": "^8.0.2",
         "strong-globalize": "^6.0.0",
         "uuid": "^9.0.0"
@@ -26,14 +26,14 @@
         "juggler-v3": "file:./deps/juggler-v3",
         "juggler-v4": "file:./deps/juggler-v4",
         "lodash": "^4.17.4",
-        "loopback-datasource-juggler": "^3.0.0 || ^4.0.0",
+        "loopback-datasource-juggler": "^4.28.0",
         "mocha": "^10.0.0",
         "rc": "^1.0.0",
         "should": "^13.2.3",
         "sinon": "^9.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "14 || 16 || 18"
       }
     },
     "deps/juggler-v3": {
@@ -2605,9 +2605,9 @@
       }
     },
     "node_modules/loopback-connector": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/loopback-connector/-/loopback-connector-5.1.0.tgz",
-      "integrity": "sha512-ZPHvyfqUywu3KGuCIySt8g+JPXwp29X/M4nJwL3PgzRL3xbKv4cX7b08cpD2sNifHEdlG1FIhF7VGvI+JhU90Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/loopback-connector/-/loopback-connector-5.1.1.tgz",
+      "integrity": "sha512-nEVn2uyddc35+5M7UCOsVcNefm9RadOT7ceeirSrapWC4tW56hPtYAEVkDeaY61fwYjj9pmxqGNBruLCi2C2CA==",
       "dependencies": {
         "async": "^3.2.4",
         "bluebird": "^3.7.2",
@@ -2629,27 +2629,36 @@
       }
     },
     "node_modules/loopback-datasource-juggler": {
-      "version": "4.27.1",
-      "resolved": "https://registry.npmjs.org/loopback-datasource-juggler/-/loopback-datasource-juggler-4.27.1.tgz",
-      "integrity": "sha512-tZ+NB55F/syrFAOBAndKXKERKmFU7w0UYT6NhbQqLFSc2eVmrk4Wfx3lULGYB9UCJAJIeDoCXJYvjThaeZ3TCQ==",
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/loopback-datasource-juggler/-/loopback-datasource-juggler-4.28.0.tgz",
+      "integrity": "sha512-Y1kwnms327FRnRBYVBLv7sckRSijHSZ+NXshEAOuzoEgBkBXfOLj8wXaBStydN/DOWwchUxmrs+YrbglTkZz+w==",
       "dev": true,
       "dependencies": {
-        "async": "^3.1.0",
-        "change-case": "^4.1.1",
-        "debug": "^4.1.0",
+        "async": "^3.2.4",
+        "change-case": "^4.1.2",
+        "debug": "^4.3.4",
         "depd": "^2.0.0",
-        "inflection": "^1.6.0",
-        "lodash": "^4.17.11",
-        "loopback-connector": "^5.0.0",
-        "minimatch": "^3.0.3",
-        "nanoid": "^3.1.20",
-        "qs": "^6.5.0",
+        "inflection": "^1.13.4",
+        "lodash": "^4.17.21",
+        "loopback-connector": "^5.1.0",
+        "minimatch": "^5.1.0",
+        "nanoid": "^3.3.4",
+        "qs": "^6.10.5",
         "strong-globalize": "^6.0.5",
-        "traverse": "^0.6.6",
-        "uuid": "^8.3.1"
+        "traverse": "^0.6.7",
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/loopback-datasource-juggler/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/loopback-datasource-juggler/node_modules/depd": {
@@ -2659,6 +2668,18 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/loopback-datasource-juggler/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/loopback-datasource-juggler/node_modules/uuid": {
@@ -6940,9 +6961,9 @@
       }
     },
     "loopback-connector": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/loopback-connector/-/loopback-connector-5.1.0.tgz",
-      "integrity": "sha512-ZPHvyfqUywu3KGuCIySt8g+JPXwp29X/M4nJwL3PgzRL3xbKv4cX7b08cpD2sNifHEdlG1FIhF7VGvI+JhU90Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/loopback-connector/-/loopback-connector-5.1.1.tgz",
+      "integrity": "sha512-nEVn2uyddc35+5M7UCOsVcNefm9RadOT7ceeirSrapWC4tW56hPtYAEVkDeaY61fwYjj9pmxqGNBruLCi2C2CA==",
       "requires": {
         "async": "^3.2.4",
         "bluebird": "^3.7.2",
@@ -6960,31 +6981,49 @@
       }
     },
     "loopback-datasource-juggler": {
-      "version": "4.27.1",
-      "resolved": "https://registry.npmjs.org/loopback-datasource-juggler/-/loopback-datasource-juggler-4.27.1.tgz",
-      "integrity": "sha512-tZ+NB55F/syrFAOBAndKXKERKmFU7w0UYT6NhbQqLFSc2eVmrk4Wfx3lULGYB9UCJAJIeDoCXJYvjThaeZ3TCQ==",
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/loopback-datasource-juggler/-/loopback-datasource-juggler-4.28.0.tgz",
+      "integrity": "sha512-Y1kwnms327FRnRBYVBLv7sckRSijHSZ+NXshEAOuzoEgBkBXfOLj8wXaBStydN/DOWwchUxmrs+YrbglTkZz+w==",
       "dev": true,
       "requires": {
-        "async": "^3.1.0",
-        "change-case": "^4.1.1",
-        "debug": "^4.1.0",
+        "async": "^3.2.4",
+        "change-case": "^4.1.2",
+        "debug": "^4.3.4",
         "depd": "^2.0.0",
-        "inflection": "^1.6.0",
-        "lodash": "^4.17.11",
-        "loopback-connector": "^5.0.0",
-        "minimatch": "^3.0.3",
-        "nanoid": "^3.1.20",
-        "qs": "^6.5.0",
+        "inflection": "^1.13.4",
+        "lodash": "^4.17.21",
+        "loopback-connector": "^5.1.0",
+        "minimatch": "^5.1.0",
+        "nanoid": "^3.3.4",
+        "qs": "^6.10.5",
         "strong-globalize": "^6.0.5",
-        "traverse": "^0.6.6",
-        "uuid": "^8.3.1"
+        "traverse": "^0.6.7",
+        "uuid": "^8.3.2"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "depd": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
           "dev": true
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
         },
         "uuid": {
           "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "IBM Corp.",
   "repository": "github:loopbackio/loopback-connector-postgresql",
   "engines": {
-    "node": ">=10"
+    "node": "14 || 16 || 18"
   },
   "scripts": {
     "pretest": "node pretest.js",
@@ -33,7 +33,7 @@
     "bluebird": "^3.4.6",
     "chalk": "^4.0.0",
     "debug": "^4.1.1",
-    "loopback-connector": "^5.0.0",
+    "loopback-connector": "^5.1.1",
     "pg": "^8.0.2",
     "strong-globalize": "^6.0.0",
     "uuid": "^9.0.0"
@@ -46,7 +46,7 @@
     "juggler-v3": "file:./deps/juggler-v3",
     "juggler-v4": "file:./deps/juggler-v4",
     "lodash": "^4.17.4",
-    "loopback-datasource-juggler": "^3.0.0 || ^4.0.0",
+    "loopback-datasource-juggler": "^4.28.0",
     "mocha": "^10.0.0",
     "rc": "^1.0.0",
     "should": "^13.2.3",

--- a/pretest.js
+++ b/pretest.js
@@ -23,7 +23,10 @@ process.env.PGPASSWORD = process.env.TEST_POSTGRESQL_PASSWORD ||
   process.env.POSTGRESQL_PASSWORD || process.env.PGPASSWORD || 'test';
 
 console.log('seeding DB with test db...');
-const psql = cp.spawn('psql', {stdio: stdio});
+const args = process.env.POSTGRESQL_DATABASE ?
+  ['-U', process.env.PGUSER, process.env.POSTGRESQL_DATABASE] :
+  ['-U', process.env.PGUSER];
+const psql = cp.spawn('psql', args, {stdio: stdio});
 sql.pipe(psql.stdin);
 psql.on('exit', function(code) {
   console.log('done seeding DB');


### PR DESCRIPTION
BREAKING CHANGE: This drops explicit, documented support for Node.js v10, v11, v12, v13, v15, v17

Signed-off-by: Samarpan Bhattacharya <this.is.samy@gmail.com>


1. Added support for multiple insert in one query using createAll() of connector. 
2. Updated some existing tests for name field of id column and added some too. This was done to test if the new getInsertedIds method works in those cases or not.


Fixes #523
See also https://github.com/loopbackio/loopback-next/issues/3357


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
