### PR TITLE
fix(migration): add dbDefault also when altering table

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -159,7 +159,7 @@ function mixinMigration(PostgreSQL) {
         model, self.column(model, propName), actualFields,
       );
       if (!found && self.propertyHasNotBeenDeleted(model, propName)) {
-        sql.push('ADD COLUMN ' + self.addPropertyToActual(model, propName));
+        sql.push('ADD COLUMN ' + self.addPropertyToActual(model, propName) + self.columnDbDefault(model, propName));
       }
     });
     if (sql.length > 0) {


### PR DESCRIPTION
Currently `dbDefault` metadata property value is used only on columns when creating table, but not when altering it. Changed that to match behaviour in both cases.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
