### PR TITLE
fix: unhandled connection errors

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -80,16 +80,7 @@ function PostgreSQL(postgresql, settings) {
   }
   this.clientConfig.Promise = Promise;
   this.pg = new postgresql.Pool(this.clientConfig);
-
-  if (settings.onError) {
-    if (settings.onError === 'ignore') {
-      this.pg.on('error', function(err) {
-        debug(err);
-      });
-    } else {
-      this.pg.on('error', settings.onError);
-    }
-  }
+  attachErrorHandler(settings, this.pg);
 
   this.settings = settings;
   debug('Settings %j', {
@@ -109,6 +100,18 @@ function PostgreSQL(postgresql, settings) {
   });
 }
 
+function attachErrorHandler(settings, pg) {
+  if (settings.onError) {
+    if (settings.onError === 'ignore') {
+      pg.on('error', function(err) {
+        debug(err);
+      });
+    } else {
+      pg.on('error', settings.onError);
+    }
+  }
+}
+
 // Inherit from loopback-datasource-juggler BaseSQL
 util.inherits(PostgreSQL, SqlConnector);
 
@@ -125,6 +128,10 @@ PostgreSQL.prototype.multiInsertSupported = true;
 PostgreSQL.prototype.connect = function(callback) {
   const self = this;
   self.pg.connect(function(err, client, releaseCb) {
+    // pg-pool requires attaching an error handler to each item checked out off the pool,
+    // which will handle connection-level errors.
+    // See https://github.com/brianc/node-postgres/issues/1324
+    attachErrorHandler(self.settings, client);
     self.client = client;
     process.nextTick(releaseCb);
     callback && callback(err, client);
@@ -194,6 +201,10 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
   } else {
     self.pg.connect(function(err, connection, releaseCb) {
       if (err) return callback(err);
+      // pg-pool requires attaching an error handler to each item checked out off the pool,
+      // which will handle connection-level errors.
+      // See https://github.com/brianc/node-postgres/issues/1324
+      attachErrorHandler(self.settings, connection);
       executeWithConnection(connection, releaseCb);
     });
   }


### PR DESCRIPTION
pg-pool requires attaching an error handler to each connection acquired from the pool, which will handle connection-level errors. Without it, the process ends up crashing whenever the connection is interrupted (e.g. database failover).

This fact can be observed in pg-pool:
- newClient [1] and _release (back to the pool) [2] attaches an "idleListener" error handler which upon encountering a connection error, destroys the connection / removes it from the pool, and re-emits [3]
- _acquireClient removes the "idleListener", leaving the returned connection without an error handler [4]

This PR is in response to production outages we have faced during Aurora PostgreSQL failovers, with the unexpected disconnections for actively-used connections turning error emits into unhandled exceptions and ultimately crashing the entire NodeJS process, despite our existing error handlers on both `.on('error'` and `.adapter.pg.on('error'`, and our catch-all try/catches.. With this patch in place, the unexpected disconnects (e.g. which could be simulated with a `tcpkill -9`) no longer crash the processes, proper errors are yielded by the queries - which can then be captured as usual, and the application can eventually recover once the database is available once again. 

See https://github.com/brianc/node-postgres/issues/1324 (and more specifically the last few comments there).

[1]: https://github.com/brianc/node-postgres/blob/4b229275cfe41ca17b7d69bd39f91ada0068a5d0/packages/pg-pool/index.js#L231
[2]: https://github.com/brianc/node-postgres/blob/4b229275cfe41ca17b7d69bd39f91ada0068a5d0/packages/pg-pool/index.js#L305C6-L305C6
[3]: https://github.com/brianc/node-postgres/blob/4b229275cfe41ca17b7d69bd39f91ada0068a5d0/packages/pg-pool/index.js#L46C1-L46C1
[4]: https://github.com/brianc/node-postgres/blob/4b229275cfe41ca17b7d69bd39f91ada0068a5d0/packages/pg-pool/index.js#L264C12-L264C12

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] Tested as fixing our production outages
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
