### PR TITLE
feat: add support for contained by operator

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -554,6 +554,10 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
       return new ParameterizedSQL(columnName + ' @> array[' + operatorValue.map(() => '?') + ']::'
         + propertyDefinition.postgresql.dataType,
       operatorValue);
+    case 'containedby':
+      return new ParameterizedSQL(columnName + ' <@ array[' + operatorValue.map(() => '?') + ']::'
+        + propertyDefinition.postgresql.dataType,
+      operatorValue);
     case 'match':
       return new ParameterizedSQL(`to_tsvector(${columnName}) @@ to_tsquery(?)`, [operatorValue]);
     default:


### PR DESCRIPTION
<!--
loopback-pg-connector supports 'contains' operator `@>`, 
which lets you check if an array type column contains any of the values listed on the other side of the operator.
postgres supports a similar operator called 'is contained by' `<@` which checks if the values on the right side of the operator is contained by the array type column. 
This feature adds support for `<@`, and the operator name is `containedby`

There are no active issues regarding this feature.

-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
