### PR TITLE
fix: return auto-increment as generated

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -137,7 +137,7 @@ function mixinDiscovery(PostgreSQL) {
         results.map(function(r) {
           // PostgreSQL returns ALWAYS in case the property is generated,
           // otherwise it returns NEVER
-          if (r.generated === 'ALWAYS') {
+          if (r.generated === 'ALWAYS' || r.identityGenerated === 'ALWAYS') {
             r.generated = true;
           } else {
             r.generated = false;
@@ -173,8 +173,9 @@ function mixinDiscovery(PostgreSQL) {
     if (owner) {
       sql = this.paginateSQL('SELECT table_schema AS "owner", table_name AS "tableName", column_name AS "columnName",'
           + 'data_type AS "dataType", character_maximum_length AS "dataLength", numeric_precision AS "dataPrecision",'
+          + ' numeric_scale AS "dataScale", is_nullable AS "nullable",'
           + ' is_generated AS "generated",'
-          + ' numeric_scale AS "dataScale", is_nullable AS "nullable"'
+          + ' identity_generation AS "identityGenerated"'
           + ' FROM information_schema.columns'
           + ' WHERE table_schema=\'' + owner + '\''
           + (table ? ' AND table_name=\'' + table + '\'' : ''),
@@ -183,8 +184,9 @@ function mixinDiscovery(PostgreSQL) {
       sql = this.paginateSQL('SELECT current_schema() AS "owner", table_name AS "tableName",'
           + ' column_name AS "columnName",'
           + ' data_type AS "dataType", character_maximum_length AS "dataLength", numeric_precision AS "dataPrecision",'
+          + ' numeric_scale AS "dataScale", is_nullable AS "nullable",'
           + ' is_generated AS "generated",'
-          + ' numeric_scale AS "dataScale", is_nullable AS "nullable"'
+          + ' identity_generation AS "identityGenerated"'
           + ' FROM information_schema.columns'
           + (table ? ' WHERE table_name=\'' + table + '\'' : ''),
       'table_name, ordinal_position', {});

--- a/test/postgresql.discover.test.js
+++ b/test/postgresql.discover.test.js
@@ -382,6 +382,16 @@ describe('Discover LDL schema from a table', function() {
       done(null, schema);
     });
   });
+
+  it('should return an LDL schema for user which has id as generated', function(done) {
+    db.discoverSchema('user', {owner: 'strongloop'}, function(err, schema) {
+      console.log('This is our err: ', err);
+      console.log('This is our schema: ', schema);
+      assert(schema.properties.id.generated);
+      assert(typeof schema.properties.id.generated === 'boolean');
+      done(null, schema);
+    });
+  });
 });
 
 describe('Discover and map correctly database types', function() {

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -268,6 +268,15 @@ CREATE TABLE "GeoPoint" (
 
 
 --
+-- Name: user; Type: TABLE; Schema: strongloop; Owner: strongloop
+--
+
+CREATE TABLE "user" (
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    email character varying(100)
+);
+
+--
 -- Name: GeoPoint_id_seq; Type: SEQUENCE; Schema: strongloop; Owner: strongloop
 --
 


### PR DESCRIPTION
With the current version of Postgres, we can have the id as auto-increment by adding an identity constraint with the value set to ALWAYS. This PR enables the connector to return the `generated` as true if a column is set to be an auto-increment with this constraint.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
