### PR TITLE
feat(operators): add containedBy and containsAnyOf operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,8 @@ CustomerRepository.find({
 PostgreSQL supports the following PostgreSQL-specific operators:
 
 - [`contains`](#operator-contains)
+- [`containedBy`](#operator-containedby)
+- [`containsAny`](#operator-containsany)
 - [`match`](#operator-match)
 
 Please note extended operators are disabled by default, you must enable
@@ -592,6 +594,88 @@ const posts = await postRepository.find({
   where: {
     {
       categories: {'contains': ['AA']},
+    }
+  }
+});
+```
+
+### Operator `containedBy`
+
+Inverse of the `contains` operator, the `containedBy` operator allow you to query array properties and pick only
+rows where the all the items in the stored value are contained by the query.
+
+The operator is implemented using PostgreSQL [array operator
+`<@`](https://www.postgresql.org/docs/current/functions-array.html).
+
+**Note** The fields you are querying must be setup to use the postgresql array data type - see [Defining models](#defining-models) above.
+
+Assuming a model such as this:
+
+```ts
+@model({
+  settings: {
+    allowExtendedOperators: true,
+  }
+})
+class Post {
+  @property({
+    type: ['string'],
+    postgresql: {
+      dataType: 'varchar[]',
+    },
+  })
+  categories?: string[];
+}
+```
+
+You can query the tags fields as follows:
+
+```ts
+const posts = await postRepository.find({
+  where: {
+    {
+      categories: {'containedBy': ['AA']},
+    }
+  }
+});
+```
+
+### Operator `containsAnyOf`
+
+The `containsAnyOf` operator allow you to query array properties and pick only
+rows where the any of the items in the stored value matches any of the items in the query.
+
+The operator is implemented using PostgreSQL [array overlap operator
+`&&`](https://www.postgresql.org/docs/current/functions-array.html).
+
+**Note** The fields you are querying must be setup to use the postgresql array data type - see [Defining models](#defining-models) above.
+
+Assuming a model such as this:
+
+```ts
+@model({
+  settings: {
+    allowExtendedOperators: true,
+  }
+})
+class Post {
+  @property({
+    type: ['string'],
+    postgresql: {
+      dataType: 'varchar[]',
+    },
+  })
+  categories?: string[];
+}
+```
+
+You can query the tags fields as follows:
+
+```ts
+const posts = await postRepository.find({
+  where: {
+    {
+      categories: {'containsAnyOf': ['AA']},
     }
   }
 });

--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -565,6 +565,14 @@ PostgreSQL.prototype.buildExpression = function(columnName, operator,
       return new ParameterizedSQL(columnName + ' @> array[' + operatorValue.map(() => '?') + ']::'
         + propertyDefinition.postgresql.dataType,
       operatorValue);
+    case 'containedBy':
+      return new ParameterizedSQL(columnName + ' <@ array[' + operatorValue.map(() => '?') + ']::'
+        + propertyDefinition.postgresql.dataType,
+      operatorValue);
+    case 'containsAnyOf':
+      return new ParameterizedSQL(columnName + ' && array[' + operatorValue.map(() => '?') + ']::'
+        + propertyDefinition.postgresql.dataType,
+      operatorValue);
     case 'match':
       return new ParameterizedSQL(`to_tsvector(${columnName}) @@ to_tsquery(?)`, [operatorValue]);
     default:

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -273,22 +273,54 @@ describe('postgresql connector', function() {
       });
   });
 
-  it('should support where filter for array type field', async () => {
-    await Post.create({
-      title: 'LoopBack Participates in Hacktoberfest',
-      categories: ['LoopBack', 'Announcements'],
+  context('array operators', () => {
+    before(deleteTestFixtures);
+    before(createTestFixtures);
+    it('should support contains filter for array type field', async () => {
+      const found = await Post.find({where: {and: [
+        {
+          categories: {'contains': ['LoopBack', 'Community']},
+        },
+      ]}});
+      found.map(p => p.title).should.deepEqual(['Growing LoopBack Community']);
     });
-    await Post.create({
-      title: 'Growing LoopBack Community',
-      categories: ['LoopBack', 'Community'],
+    it('should support containedBy filter for array type field', async () => {
+      const found = await Post.find({where: {and: [
+        {
+          categories: {'containedBy': ['LoopBack', 'Community', 'SomethingElse']},
+        },
+      ]}});
+      found.map(p => p.title).should.deepEqual(['Growing LoopBack Community']);
     });
-
-    const found = await Post.find({where: {and: [
-      {
-        categories: {'contains': ['LoopBack', 'Community']},
-      },
-    ]}});
-    found.map(p => p.title).should.deepEqual(['Growing LoopBack Community']);
+    it('should support containsAnyOf filter for array type field', async () => {
+      const found = await Post.find({where: {and: [
+        {
+          categories: {'containsAnyOf': ['LoopBack']},
+        },
+      ]}});
+      found.map(p => p.title).should.deepEqual([
+        'LoopBack Participates in Hacktoberfest',
+        'Growing LoopBack Community',
+      ]);
+    });
+    function deleteTestFixtures(done) {
+      Post.destroyAll(function(err) {
+        should.not.exist(err);
+        done();
+      });
+    }
+    function createTestFixtures(done) {
+      Post.createAll([
+        {
+          title: 'LoopBack Participates in Hacktoberfest',
+          categories: ['LoopBack', 'Hacktoberfest'],
+        },
+        {
+          title: 'Growing LoopBack Community',
+          categories: ['LoopBack', 'Community'],
+        },
+      ], done);
+    }
   });
 
   it('should support full text search for text type fields using simple string query', async () => {


### PR DESCRIPTION
- adds operators `containedBy` and `containsAnyOf` using the `<@` and  `&&` operators in postgresql.
- Restructured array operators tests to avoid duplication
- added tests for `containedBy` and `containsAny`
- based on original PR by [Hazım Dikenli](https://github.com/hazimdikenli) - https://github.com/loopbackio/loopback-connector-postgresql/pull/640

Co-authored-by: Hazım Dikenli <hazim.dikenli@atez.com.tr>

## Checklist

- [X] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [X] `npm test` passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [X] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
