### PR TITLE
Fix: Connection terminated unexpectedly error not caught in on error listener

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -103,11 +103,19 @@ function PostgreSQL(postgresql, settings) {
 function attachErrorHandler(settings, pg) {
   if (settings.onError) {
     if (settings.onError === 'ignore') {
-      pg.on('error', function(err) {
-        debug(err);
-      });
+      // Check if the error handler is already attached
+      // to avoid possible memory leak 
+      if (!pg.listenerCount('error')) {
+        pg.on('error', function (err) {
+          debug(err);
+        });
+     }
     } else {
-      pg.on('error', settings.onError);
+      // Check if the error handler is already attached
+      // to avoid possible memory leak
+      if (!pg.listenerCount('error')) {
+        pg.on('error', settings.onError);
+      }
     }
   }
 }
@@ -165,8 +173,6 @@ PostgreSQL.prototype.executeSQL = function(sql, params, options, callback) {
       // Release the connection back to the pool.
       if (releaseCb) {
         releaseCb(err);
-        // Remove error event listener to avoid possible memory leak
-        connection.removeAllListeners('error');
       }
       let result = null;
       if (data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2858,9 +2858,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.0.tgz",
-      "integrity": "sha512-bXfLy/mI8n4QICg+pWj1G8VduX5vC0SHRwFpiR5/Fxc8S2G906pSfkyMmHVsdJNQJQNh3LE67koad9GzEvkV6g==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
+      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3340,14 +3340,14 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.1.tgz",
-      "integrity": "sha512-5n6e7MgF5ABRsssOsX9xC95p+NUuhgDQDBSsrKSZJjYVqZHGyrmJuknym2IbVhGtzV9siBdzH9SEIQAuWF+sdg==",
+      "version": "8.16.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.2.tgz",
+      "integrity": "sha512-OtLWF0mKLmpxelOt9BqVq83QV6bTfsS0XLegIeAKqKjurRnRKie1Dc1iL89MugmSLhftxw6NNCyZhm1yQFLMEQ==",
       "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
-        "pg-protocol": "^1.10.1",
+        "pg-protocol": "^1.10.2",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -3398,9 +3398,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.1.tgz",
-      "integrity": "sha512-9YS3ZonDj0Lxny//aF0ITPdfrEPgKWCJvONsSXAaIUhgpzlzl5JgaZNlbTFxvYNfm2terGEnHeOSUlF6qRGBzw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.2.tgz",
+      "integrity": "sha512-Ci7jy8PbaWxfsck2dwZdERcDG2A0MG8JoQILs+uZNjABFuBuItAZCWUNz8sXRDMoui24rJw7WlXqgpMdBSN/vQ==",
       "license": "MIT"
     },
     "node_modules/pg-types": {


### PR DESCRIPTION
Our application was crashing when the database connection unexpectedly failed. This happened because:

1. We were previously using removeAllListeners('error'), which unintentionally removed the pg library's error handlers.
2. This left connection termination errors unhandled, leading to app crashes which uses this connector

We've fixed this by:
1. Completely removing the `removeAllListeners('error')` call within the connector.  This ensures that the pg library's built-in error handling for connection issues remains active.
2. We now only add our connector's specific error listener if the pg client doesn't already have any error listeners attached `(!pg.listenerCount('error'))`. This prevents us from creating too many listeners (addressing past MaxEventListeners warnings) while ensuring all critical connection errors are still properly managed.

Fixes #778 
See also #746

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
