### PR TITLE
chore: drop Node.js 18 support

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        node-version: [18, 20, 22] # Maintenance, Active LTS & Current
+        node-version: [20, 22, 24] # Maintenance, Active LTS & Current
       fail-fast: false
     services:
       postgres:

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   ],
   "license": "Artistic-2.0",
   "main": "index.js",
-  "author": "IBM Corp.",
+  "author": "IBM Corp. and LoopBack contributors",
   "repository": "github:loopbackio/loopback-connector-postgresql",
   "engines": {
-    "node": "18 || 20 || 22"
+    "node": ">=20"
   },
   "scripts": {
     "pretest": "node pretest.js",


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js 18 support

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
