### PR TITLE
chore: drop Node.js 20 support

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        node-version: [20, 22, 24] # Maintenance, Active LTS & Current
+        node-version: [22, 24, 26] # Maintenance, Active LTS & Current
       fail-fast: false
     services:
       postgres:

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "sinon": "^21.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "IBM Corp. and LoopBack contributors",
   "repository": "github:loopbackio/loopback-connector-postgresql",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "pretest": "node pretest.js",


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Node.js 20 has reached end of life ([link](https://github.com/nodejs/Release)), so dropping its support.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
